### PR TITLE
Update bottom bar layout and implement daily/yesterday todo features

### DIFF
--- a/app/src/main/java/com/chch/tudoong/data/local/database/dao/TodoDao.kt
+++ b/app/src/main/java/com/chch/tudoong/data/local/database/dao/TodoDao.kt
@@ -34,6 +34,9 @@ interface TodoDao {
     @Query("DELETE FROM todo_items WHERE type = :type")
     suspend fun deleteAllTodosByType(type: TodoType)
 
+    @Query("DELETE FROM todo_items")
+    suspend fun deleteAllTodos()
+
     @Query("UPDATE todo_items SET type = 'YESTERDAY' WHERE type = 'TODAY'")
     suspend fun moveTodayToYesterday()
 }

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -1,6 +1,7 @@
 package com.chch.tudoong.data.repository
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import com.chch.tudoong.data.local.database.dao.DailyDao
 import com.chch.tudoong.data.local.database.dao.MetadataDao
@@ -80,11 +81,11 @@ class TudoongRepository @Inject constructor(
             else -> false
         }
 
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
         if (needsReset) {
             performReset(today)
         }
+
     }
 
     private suspend fun performReset(today: String) {
@@ -92,11 +93,10 @@ class TudoongRepository @Inject constructor(
         val metadata = metadataDao.getMetadata() ?: AppMetadata()
         val yesterday = getYesterdayDate(today) // 어제 날짜를 계산하는 함수
 
-
         if (metadata.todayDate == yesterday) {
             todoDao.moveTodayToYesterday()
         } else if (metadata.todayDate.isNotEmpty()) {
-            todoDao.deleteAllTodosByType(TodoType.TODAY)
+            todoDao.deleteAllTodos()
         }
 
         val dailyItems = dailyDao.getAllDailyItems()

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -1,5 +1,7 @@
 package com.chch.tudoong.data.repository
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.chch.tudoong.data.local.database.dao.DailyDao
 import com.chch.tudoong.data.local.database.dao.MetadataDao
 import com.chch.tudoong.data.local.database.dao.TodoDao
@@ -8,6 +10,7 @@ import com.chch.tudoong.data.local.database.entities.DailyItem
 import com.chch.tudoong.data.local.database.entities.TodoItem
 import com.chch.tudoong.domain.model.TodoType
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
@@ -64,6 +67,7 @@ class TudoongRepository @Inject constructor(
         metadataDao.updateResetHour(hour)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     suspend fun checkAndResetIfNeeded() {
         val metadata = getMetadata()
         val today = dateFormat.format(Date())
@@ -76,16 +80,25 @@ class TudoongRepository @Inject constructor(
             else -> false
         }
 
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
         if (needsReset) {
             performReset(today)
         }
     }
 
     private suspend fun performReset(today: String) {
-        // 1. 오늘의 할일을 어제로 이동
-        todoDao.moveTodayToYesterday()
 
-        // 2. 데일리 아이템들을 오늘의 할일로 추가
+        val metadata = metadataDao.getMetadata() ?: AppMetadata()
+        val yesterday = getYesterdayDate(today) // 어제 날짜를 계산하는 함수
+
+
+        if (metadata.todayDate == yesterday) {
+            todoDao.moveTodayToYesterday()
+        } else if (metadata.todayDate.isNotEmpty()) {
+            todoDao.deleteAllTodosByType(TodoType.TODAY)
+        }
+
         val dailyItems = dailyDao.getAllDailyItems()
         val todayTodos = dailyItems.map { dailyItem ->
             TodoItem(
@@ -98,8 +111,23 @@ class TudoongRepository @Inject constructor(
             todoDao.insertTodos(todayTodos)
         }
 
-        // 4. 메타데이터 업데이트
+        // 메타데이터 업데이트
         metadataDao.updateLastResetDate(today)
         metadataDao.updateTodayDate(today)
+    }
+
+    private fun getYesterdayDate(today: String): String? {
+        return try {
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val todayDate = dateFormat.parse(today)
+
+            val calendar = Calendar.getInstance()
+            calendar.time = todayDate
+            calendar.add(Calendar.DAY_OF_MONTH, -1)
+
+            dateFormat.format(calendar.time)
+        } catch (e: Exception) {
+            null
+        }
     }
 }

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -1,7 +1,6 @@
 package com.chch.tudoong.data.repository
 
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import com.chch.tudoong.data.local.database.dao.DailyDao
 import com.chch.tudoong.data.local.database.dao.MetadataDao
@@ -11,7 +10,6 @@ import com.chch.tudoong.data.local.database.entities.DailyItem
 import com.chch.tudoong.data.local.database.entities.TodoItem
 import com.chch.tudoong.domain.model.TodoType
 import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/component/AnimatedModeButton.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/component/AnimatedModeButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
@@ -28,7 +29,7 @@ fun AnimatedModeButton(
         targetValue = if (isActive)
             MaterialTheme.colorScheme.primary
         else
-            MaterialTheme.colorScheme.surfaceVariant,
+            Color.Transparent,
         animationSpec = tween(300),
         label = "background_color"
     )

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/component/CheckableRow.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/component/CheckableRow.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,20 +22,18 @@ import androidx.compose.ui.unit.dp
 import com.chch.tudoong.data.local.database.entities.TodoItem
 import com.chch.tudoong.presentation.ui.component.AnimatedCheckbox
 import com.chch.tudoong.presentation.ui.main.EditMode
-import com.chch.tudoong.presentation.ui.main.TudoongItem
-
 
 
 @Composable
 fun CheckableRow(
     item: TodoItem,
+    isDailyItem: Boolean,
     mode: EditMode = EditMode.VIEW,
     onCheckedChange: (Boolean) -> Unit,
     onDelete: (TodoItem) -> Unit,
-    onEdit: (TodoItem) -> Unit
+    onEdit: (TodoItem) -> Unit,
+    onToggleDaily: (String) -> Unit
 ) {
-    val textColor = MaterialTheme.colorScheme.primary
-    val disableTextColor = MaterialTheme.colorScheme.onSurface.copy(0.38f)
 
     Row(
         modifier = Modifier
@@ -73,6 +73,18 @@ fun CheckableRow(
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            EditMode.VIEW -> {
+                IconButton(
+                    onClick = { onToggleDaily.invoke(item.text) }
+                ) {
+                    Icon(
+                        if (isDailyItem) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = "Add a daily item",
                         tint = MaterialTheme.colorScheme.primary
                     )
                 }

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/DailyBottomSheet.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/DailyBottomSheet.kt
@@ -1,0 +1,78 @@
+package com.chch.tudoong.presentation.ui.main
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.chch.tudoong.data.local.database.entities.DailyItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DailyBottomSheet(
+    list: List<DailyItem> = listOf(),
+    delete: (DailyItem) -> Unit,
+    dismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxHeight(),
+        sheetState = sheetState,
+        onDismissRequest = { dismiss.invoke() }
+    ) {
+        Column(
+            Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(20.dp))
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize()
+            )
+            {
+                itemsIndexed(list) { index, item ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(text = item.text)
+                        Spacer(Modifier.weight(1f))
+                        IconButton(
+                            onClick = {
+                                delete.invoke(item)
+                            }
+                        ) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete daily item",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -82,6 +82,7 @@ fun MainScreen(
     var showYesterdayBottomSheet by remember { mutableStateOf(false) }
 
     fun resetInputState() {
+        editMode = EditMode.VIEW
         showInput = false
         inputText = ""
         editUUID = null

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -29,9 +29,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material.icons.filled.ModeEdit
-import androidx.compose.material.icons.filled.PunchClock
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -74,6 +72,7 @@ fun MainScreen(
     var showInput by remember { mutableStateOf(false) }
     var inputText by remember { mutableStateOf("") }
     var editMode by remember { mutableStateOf(EditMode.VIEW) }
+    var editUUID by remember { mutableStateOf<String?>(null) }
 
     val today = Calendar.getInstance()
     val formatter = SimpleDateFormat("M월 d일", Locale.KOREAN)
@@ -85,6 +84,7 @@ fun MainScreen(
     fun resetInputState() {
         showInput = false
         inputText = ""
+        editUUID = null
     }
 
     fun handleChecklistInput() {
@@ -95,7 +95,11 @@ fun MainScreen(
                 }
 
                 EditMode.EDIT -> {
-                    // TODO
+                    editUUID?.let {
+                        viewModel.updateTodoItem(
+                            uiState.todayTodos.first { it.id == editUUID }.copy(text = inputText)
+                        )
+                    }
                 }
 
                 else -> { /* Do Nothing */
@@ -234,6 +238,7 @@ fun MainScreen(
                         },
                         onEdit = {
                             inputText = it.text
+                            editUUID = it.id
                             showInput = true
                         },
                         onDelete = {
@@ -316,7 +321,7 @@ fun MainScreen(
             }
         }
 
-        if(showYesterdayBottomSheet){
+        if (showYesterdayBottomSheet) {
             YesterdayListBottomSheet(
                 list = uiState.yesterdayTodos,
                 add = {

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -23,11 +23,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ListAlt
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material.icons.filled.PunchClock
 import androidx.compose.material.icons.filled.Settings
@@ -78,6 +80,7 @@ fun MainScreen(
     val formattedDate = formatter.format(today.time)
 
     var showDailyBottomSheet by remember { mutableStateOf(false) }
+    var showYesterdayBottomSheet by remember { mutableStateOf(false) }
 
     fun resetInputState() {
         showInput = false
@@ -198,10 +201,11 @@ fun MainScreen(
 
                     AnimatedModeButton(
                         isActive = false,
-                        icon = Icons.Default.PunchClock,
-                        contentDescription = "Reset Time",
+                        icon = Icons.AutoMirrored.Filled.ListAlt,
+                        contentDescription = "Yesterday List",
                         onClick = {
-                            // TODO
+                            resetInputState()
+                            showYesterdayBottomSheet = true
                         }
                     )
                 }
@@ -310,6 +314,18 @@ fun MainScreen(
             ) {
                 showDailyBottomSheet = false
             }
+        }
+
+        if(showYesterdayBottomSheet){
+            YesterdayListBottomSheet(
+                list = uiState.yesterdayTodos,
+                add = {
+                    viewModel.addTodoItem(it)
+                }
+            ) {
+                showYesterdayBottomSheet = false
+            }
+
         }
 
     }

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -25,7 +26,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.ModeEdit
+import androidx.compose.material.icons.filled.PunchClock
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -47,6 +51,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -123,38 +128,70 @@ fun MainScreen(
             BottomAppBar(
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
             ) {
+                // LEFT BUTTONS
+                Row(
+                    modifier = Modifier.weight(2f),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    AnimatedModeButton(
+                        isActive = editMode == EditMode.EDIT,
+                        icon = Icons.Default.ModeEdit,
+                        contentDescription = "Edit Mode Button",
+                        onClick = {
+                            editMode = if (editMode != EditMode.EDIT) EditMode.EDIT else EditMode.VIEW
+                        }
+                    )
 
-                AnimatedModeButton(
-                    isActive = editMode == EditMode.EDIT,
-                    icon = Icons.Default.ModeEdit,
-                    contentDescription = "Edit Mode Button",
-                    onClick = {
-                        editMode = if (editMode != EditMode.EDIT) EditMode.EDIT else EditMode.VIEW
-                    }
-                )
+                    AnimatedModeButton(
+                        isActive = editMode == EditMode.DELETE,
+                        icon = Icons.Default.Delete,
+                        contentDescription = "Delete Mode Button",
+                        onClick = {
+                            editMode =
+                                if (editMode != EditMode.DELETE) EditMode.DELETE else EditMode.VIEW
+                        }
+                    )
+                }
 
-                AnimatedModeButton(
-                    isActive = editMode == EditMode.DELETE,
-                    icon = Icons.Default.Delete,
-                    contentDescription = "Delete Mode Button",
-                    onClick = {
-                        editMode =
-                            if (editMode != EditMode.DELETE) EditMode.DELETE else EditMode.VIEW
-                    }
-                )
-
-                Spacer(Modifier.weight(1f))
                 FloatingActionButton(
                     onClick = {
-                        showInput = true
-                        editMode = if (editMode != EditMode.ADD) EditMode.ADD else EditMode.VIEW
+                        if(editMode == EditMode.ADD){
+                            showInput = false
+                            editMode = EditMode.VIEW
+                        } else {
+                            showInput = true
+                            editMode = EditMode.ADD
+                        }
                     },
-                    modifier = Modifier.size(56.dp),
+                    modifier = Modifier.size(56.dp).weight(1f),
                     shape = CircleShape
                 ) {
                     Icon(
-                        Icons.Default.Add,
+                        if(editMode == EditMode.ADD) Icons.Default.KeyboardArrowDown else Icons.Default.Add,
                         contentDescription = "Add an item"
+                    )
+                }
+
+                // RIGHT BUTTONS 
+                Row(
+                    modifier = Modifier.weight(2f),
+                    horizontalArrangement = Arrangement.End) {
+                    AnimatedModeButton(
+                        isActive = false,
+                        icon = Icons.Default.Favorite ,
+                        contentDescription = "Daily list",
+                        onClick = {
+                            // TODO
+                        }
+                    )
+
+                    AnimatedModeButton(
+                        isActive = false,
+                        icon = Icons.Default.PunchClock,
+                        contentDescription = "Reset Time",
+                        onClick = {
+                            // TODO
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/YesterdayListBottomSheet.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/YesterdayListBottomSheet.kt
@@ -1,0 +1,153 @@
+package com.chch.tudoong.presentation.ui.main
+
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.chch.tudoong.data.local.database.entities.DailyItem
+import com.chch.tudoong.data.local.database.entities.TodoItem
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun YesterdayListBottomSheet(
+    list: List<TodoItem> = listOf(),
+    add: (String) -> Unit,
+    dismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    val completedList = list.filter { it.isCompleted }
+    val notCompletedList = list.filter { !it.isCompleted }
+    var formattedDate : String? = null
+    list.firstOrNull()?.let {
+        val date = Date(it.createdAt)
+        val formatter = SimpleDateFormat("M월 d일", Locale.KOREAN)
+        formattedDate= formatter.format(date)
+    }
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxHeight(),
+        sheetState = sheetState,
+        onDismissRequest = { dismiss.invoke() }
+    ) {
+        Column(
+            Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(20.dp))
+
+            if(formattedDate != null){
+                Text(text=formattedDate, style = MaterialTheme.typography.headlineSmall)
+                Text(text="지난 TODOs", style = MaterialTheme.typography.bodyMedium)
+            } else {
+                Text(text = "어제는 들르지 않으셨군요! 그래도 괜찮습니다:)")
+            }
+
+            if(completedList.isNotEmpty()){
+                Text(
+                    "완료한 TODOs",
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp)
+                )
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth()
+                )
+                {
+                    itemsIndexed(completedList) { index, item ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(52.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(text = "- " + item.text)
+                            Spacer(Modifier.weight(1f))
+                            IconButton(
+                                onClick = {
+                                    add.invoke(item.text)
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Default.Add,
+                                    contentDescription = "add to today",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+
+            if(notCompletedList.isNotEmpty()){
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    "완료하지 못 한 TODOs",
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp)
+                )
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    itemsIndexed(notCompletedList) { index, item ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(52.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(text = "- " + item.text)
+                            Spacer(Modifier.weight(1f))
+                            IconButton(
+                                onClick = {
+                                    add.invoke(item.text)
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Default.Add,
+                                    contentDescription = "add to today",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/chch/tudoong/presentation/viewmodel/TudoongViewModel.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/viewmodel/TudoongViewModel.kt
@@ -65,6 +65,8 @@ class TudoongViewModel @Inject constructor(
     }
 
     fun addTodoItem(text: String) {
+        if(uiState.value.todayTodos.any{ it.text == text}) return
+
         viewModelScope.launch {
             try {
                 repository.addTodoItem(text)
@@ -107,6 +109,8 @@ class TudoongViewModel @Inject constructor(
     }
 
     fun addDailyItem(text: String) {
+        if (uiState.value.dailyItems.any { it.text == text }) return
+
         viewModelScope.launch {
             try {
                 repository.addDailyItem(text)


### PR DESCRIPTION
### Changes
- Refactored bottom bar layout to center FAB with side buttons
- Added button to display yesterday's todo list in a bottom sheet
- Implemented daily todo list add/delete functionality and bottom sheet UI
- Enabled edit action for todo items and applied changes to the database
- Updated performReset() logic:
  - If metadata date is yesterday, move today's todos to yesterday
  - If not, delete all todos
- Added reset of editMode in resetInputState()