### PR TITLE
Add feature to set and display reset time

### DIFF
--- a/app/src/main/java/com/chch/tudoong/data/local/database/dao/MetadataDao.kt
+++ b/app/src/main/java/com/chch/tudoong/data/local/database/dao/MetadataDao.kt
@@ -14,8 +14,8 @@ interface MetadataDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrUpdateMetadata(metadata: AppMetadata)
 
-    @Query("UPDATE app_metadata SET resetHour = :hour WHERE id = 1")
-    suspend fun updateResetHour(hour: Int)
+    @Query("UPDATE app_metadata SET resetHour = :hour, resetMin = :min WHERE id = 1")
+    suspend fun updateResetHour(hour: Int, min: Int)
 
     @Query("UPDATE app_metadata SET lastResetDate = :date WHERE id = 1")
     suspend fun updateLastResetDate(date: String)

--- a/app/src/main/java/com/chch/tudoong/data/local/database/entities/AppMetaData.kt
+++ b/app/src/main/java/com/chch/tudoong/data/local/database/entities/AppMetaData.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 data class AppMetadata(
     @PrimaryKey val id: Int = 1, // 단일 설정 레코드
     val resetHour: Int = 7, // 리셋 시간 (24시간 형식)
+    val resetMin: Int = 0, // 리셋 분 (0-59)
     val lastResetDate: String = "", // "yyyy-MM-dd" 형식
     val todayDate: String = "" // "yyyy-MM-dd" 형식
 )

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -7,6 +7,7 @@ import com.chch.tudoong.data.local.database.entities.AppMetadata
 import com.chch.tudoong.data.local.database.entities.DailyItem
 import com.chch.tudoong.data.local.database.entities.TodoItem
 import com.chch.tudoong.domain.model.TodoType
+import com.chch.tudoong.utils.DateUtils
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -68,10 +69,11 @@ class TudoongRepository @Inject constructor(
         val metadata = getMetadata()
         val today = dateFormat.format(Date())
         val currentHour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+        val currentMin = Calendar.getInstance().get(Calendar.MINUTE)
 
         // 리셋이 필요한지 확인
         val needsReset = when {
-            metadata.lastResetDate != today && currentHour >= metadata.resetHour -> true // 날짜 바뀜 & 리셋 시간 지남
+            metadata.lastResetDate != today && currentHour >= metadata.resetHour && currentMin >= metadata.resetMin -> true // 날짜 바뀜 & 리셋 시간 지남
             else -> false
         }
 
@@ -84,7 +86,7 @@ class TudoongRepository @Inject constructor(
     private suspend fun performReset(today: String) {
 
         val metadata = metadataDao.getMetadata() ?: AppMetadata()
-        val yesterday = getYesterdayDate(today) // 어제 날짜를 계산하는 함수
+        val yesterday = DateUtils.getYesterdayDate(today) // 어제 날짜를 계산하는 함수
 
         if (metadata.todayDate == yesterday) {
             todoDao.moveTodayToYesterday()
@@ -107,20 +109,5 @@ class TudoongRepository @Inject constructor(
         // 메타데이터 업데이트
         metadataDao.updateLastResetDate(today)
         metadataDao.updateTodayDate(today)
-    }
-
-    private fun getYesterdayDate(today: String): String? {
-        return try {
-            val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-            val todayDate = dateFormat.parse(today)
-
-            val calendar = Calendar.getInstance()
-            calendar.time = todayDate
-            calendar.add(Calendar.DAY_OF_MONTH, -1)
-
-            dateFormat.format(calendar.time)
-        } catch (e: Exception) {
-            null
-        }
     }
 }

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -60,8 +60,8 @@ class TudoongRepository @Inject constructor(
         dailyDao.deleteDailyItem(dailyItem)
     }
 
-    suspend fun updateResetHour(hour: Int) {
-        metadataDao.updateResetHour(hour)
+    suspend fun updateResetHour(hour: Int, min: Int) {
+        metadataDao.updateResetHour(hour, min)
     }
 
     suspend fun checkAndResetIfNeeded() {

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/component/ResetTimeDialog.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/component/ResetTimeDialog.kt
@@ -1,0 +1,2 @@
+package com.chch.tudoong.presentation.ui.component
+

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/component/ResetTimeDialog.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/component/ResetTimeDialog.kt
@@ -1,2 +1,28 @@
 package com.chch.tudoong.presentation.ui.component
 
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ResetTimeDialog(
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+    content: @Composable () -> Unit
+){
+    AlertDialog(
+        onDismissRequest = onCancel,
+        dismissButton = {
+            TextButton(onClick = onCancel) {
+                Text("Cancel")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Save")
+            }
+        },
+        text = { content() }
+    )
+}

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/component/SettingsPopover.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/component/SettingsPopover.kt
@@ -1,0 +1,144 @@
+package com.chch.tudoong.presentation.ui.component
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+
+@Composable
+fun SettingsPopover( // ColumnPopover, only for project settings
+    list: List<SettingItem>,
+    dismiss: () -> Unit
+) {
+
+    var popupSize by remember {
+        mutableStateOf(IntSize.Zero)
+    }
+    val containerColor = MaterialTheme.colorScheme.primaryContainer
+    val anchorHeight = 10.dp
+
+    BackHandler {
+        dismiss.invoke()
+    }
+
+
+    Popup(
+        popupPositionProvider = SettingPopoverPositionProvider(),
+        onDismissRequest = dismiss
+    ) {
+
+        Column(
+            modifier = Modifier
+                .onSizeChanged {
+                    popupSize = it
+                }
+        ) {
+
+            //Draw Anchor
+            Box(
+                modifier = Modifier
+                    .height(10.dp)
+                    .drawBehind {
+                        val width = 12.dp.toPx()
+                        val height = anchorHeight.toPx()
+                        val popupWidth = popupSize.width.dp.value
+                        val startX = popupWidth - 24.dp.toPx()
+                        val inputPortPath = Path().apply {
+                            moveTo(startX, 0f)
+                            lineTo(startX - width / 2, height)
+                            lineTo(startX + width / 2, height)
+                            lineTo(startX, 0f)
+                            close()
+                        }
+
+                        drawIntoCanvas { c ->
+                            c.drawOutline(
+                                outline = Outline.Generic(inputPortPath),
+                                paint = Paint().apply {
+                                    this.color = containerColor
+                                    this.style = PaintingStyle.Fill
+                                    this.strokeWidth = strokeWidth
+                                    pathEffect = PathEffect.cornerPathEffect(1.dp.toPx())
+                                }
+                            )
+
+                        }
+                    }
+            )
+
+            // list
+            LazyColumn(
+                modifier = Modifier
+                    .width(200.dp)
+                    .background(containerColor, shape = RoundedCornerShape(10.dp))
+            ) {
+                itemsIndexed(list) { index, item ->
+                    Text(
+                        text = item.label,
+                        modifier = Modifier
+                            .padding(horizontal = 10.dp, vertical = 10.dp)
+                            .clickable(true, onClick = item.onClick)
+                    )
+                    if (index != list.size - 1) {
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+
+    }
+}
+
+class SettingPopoverPositionProvider(
+    private val x: Int = 0,
+    private val y: Int = 0
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        return IntOffset(
+            anchorBounds.right - popupContentSize.width - 5.dp.value.toInt(),
+            anchorBounds.bottom
+        )
+    }
+}
+
+data class SettingItem(
+    val label: String,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -43,8 +43,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TimePicker
-import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -86,11 +87,21 @@ fun MainScreen(
     var showSettingsPopover by remember { mutableStateOf(false) }
     var showResetTimeSettingDlg by remember { mutableStateOf(false) }
 
-    val timePickerState = rememberTimePickerState(
-        initialHour = uiState.metadata.resetHour,
-        initialMinute = uiState.metadata.resetMin,
-        is24Hour = true
-    )
+//    val timePickerState = rememberTimePickerState(
+//        initialHour = uiState.metadata.resetHour,
+//        initialMinute = uiState.metadata.resetMin,
+//        is24Hour = true
+//    )
+
+    var timePickerState by remember { mutableStateOf<TimePickerState?>(null) }
+
+    LaunchedEffect(uiState.metadata.resetHour, uiState.metadata.resetMin) {
+        timePickerState = TimePickerState(
+            initialHour = uiState.metadata.resetHour,
+            initialMinute = uiState.metadata.resetMin,
+            is24Hour = true
+        )
+    }
 
     fun resetInputState() {
         editMode = EditMode.VIEW
@@ -379,18 +390,21 @@ fun MainScreen(
 
         }
 
-        if (showResetTimeSettingDlg) {
-            ResetTimeDialog(
-                onCancel = { showResetTimeSettingDlg = false },
-                onConfirm = {
-                    showResetTimeSettingDlg = false
-                    viewModel.updateResetHour(timePickerState.hour, timePickerState.minute)
-                },
-                content = {
-                    TimePicker(state = timePickerState)
-                }
-            )
+        timePickerState?.let { tps ->
+            if (showResetTimeSettingDlg) {
+                ResetTimeDialog(
+                    onCancel = { showResetTimeSettingDlg = false },
+                    onConfirm = {
+                        showResetTimeSettingDlg = false
+                        viewModel.updateResetHour(tps.hour, tps.minute)
+                    },
+                    content = {
+                        TimePicker(state = tps)
+                    }
+                )
+            }
         }
+
 
     }
 }

--- a/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/ui/main/MainScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirst
 import com.chch.mycompose.ui.screen.checklist.CheckableRow
 import com.chch.tudoong.presentation.ui.component.AnimatedModeButton
+import com.chch.tudoong.presentation.ui.component.SettingItem
+import com.chch.tudoong.presentation.ui.component.SettingsPopover
 import com.chch.tudoong.presentation.viewmodel.TudoongViewModel
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -80,6 +82,8 @@ fun MainScreen(
 
     var showDailyBottomSheet by remember { mutableStateOf(false) }
     var showYesterdayBottomSheet by remember { mutableStateOf(false) }
+
+    var showSettingsPopover by remember { mutableStateOf(false) }
 
     fun resetInputState() {
         editMode = EditMode.VIEW
@@ -129,11 +133,27 @@ fun MainScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { /* do something */ }) {
-                        Icon(
-                            imageVector = Icons.Filled.Settings,
-                            contentDescription = "setting icon"
-                        )
+
+                    Box {
+                        IconButton(onClick = { showSettingsPopover = true }) {
+                            Icon(
+                                imageVector = Icons.Filled.Settings,
+                                contentDescription = "setting icon"
+                            )
+                        }
+
+                        if (showSettingsPopover) {
+                            SettingsPopover(
+                                listOf(
+                                    SettingItem(
+                                        label = "리셋 타임 설정",
+                                        onClick = { showSettingsPopover = false })
+                                )
+                            ) {
+                                showSettingsPopover = false
+                            }
+                        }
+
                     }
                 }
             )

--- a/app/src/main/java/com/chch/tudoong/presentation/viewmodel/TudoongViewModel.kt
+++ b/app/src/main/java/com/chch/tudoong/presentation/viewmodel/TudoongViewModel.kt
@@ -146,10 +146,10 @@ class TudoongViewModel @Inject constructor(
         }
     }
 
-    fun updateResetHour(hour: Int) {
+    fun updateResetHour(hour: Int, min: Int) {
         viewModelScope.launch {
             try {
-                repository.updateResetHour(hour)
+                repository.updateResetHour(hour, min)
                 val updatedMetadata = repository.getMetadata()
                 _uiState.value = _uiState.value.copy(metadata = updatedMetadata)
             } catch (e: Exception) {

--- a/app/src/main/java/com/chch/tudoong/utils/DateUtils.kt
+++ b/app/src/main/java/com/chch/tudoong/utils/DateUtils.kt
@@ -1,0 +1,73 @@
+package com.chch.tudoong.utils
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+object DateUtils {
+
+    fun formatDateToShort(dateString: String): String {
+        return try {
+            if (dateString.isEmpty()) return ""
+
+            val parts = dateString.split("-")
+            if (parts.size == 3) {
+                val month = parts[1].toInt()
+                val day = parts[2].toInt()
+                "$month/$day"
+            } else {
+                dateString
+            }
+        } catch (e: Exception) {
+            dateString
+        }
+    }
+
+    fun formatDateWithDayOfWeek(dateString: String): String {
+        return try {
+            if (dateString.isEmpty()) return ""
+
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val date = dateFormat.parse(dateString)
+
+            val calendar = Calendar.getInstance()
+            calendar.time = date
+
+            val month = calendar.get(Calendar.MONTH) + 1
+            val day = calendar.get(Calendar.DAY_OF_MONTH)
+            val dayOfWeek = when (calendar.get(Calendar.DAY_OF_WEEK)) {
+                Calendar.SUNDAY -> "SUN"
+                Calendar.MONDAY -> "MON"
+                Calendar.TUESDAY -> "TUE"
+                Calendar.WEDNESDAY -> "WED"
+                Calendar.THURSDAY -> "THU"
+                Calendar.FRIDAY -> "FRI"
+                Calendar.SATURDAY -> "SAT"
+                else -> ""
+            }
+
+            "$month/$day($dayOfWeek)"
+        } catch (e: Exception) {
+            dateString
+        }
+    }
+
+    fun getCurrentDate(): String {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        return dateFormat.format(Date())
+    }
+
+    fun getYesterdayDate(today: String): String? {
+        return try {
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val todayDate = dateFormat.parse(today)
+
+            val calendar = Calendar.getInstance()
+            calendar.time = todayDate
+            calendar.add(Calendar.DAY_OF_MONTH, -1)
+
+            dateFormat.format(calendar.time)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the ResetTimeDialog that allows users to set the reset time using a TimePicker. The selected reset time is now displayed together with the date on the MainScreen. 

Additional changes:
- Added resetMin support in AppMetadata and updated related time reset logic
- Implemented validation for reset hour and minute values
- Created a DateUtils object for date formatting
- Added SettingsPopover composable for improved settings UI