### PR TITLE
feat: Add Glance widget

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,8 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
+
+    // Glance for Widget
+    implementation(libs.androidx.glance.appwidget)
+    implementation(libs.androidx.glance.material3)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
@@ -82,4 +83,10 @@ dependencies {
     // Glance for Widget
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.glance.material3)
+
+
+    //생명주기 이벤트
+    implementation(libs.androidx.lifecycle.process)
+
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+
+
     <application
         android:name=".TudoongApplication"
         android:allowBackup="true"
@@ -13,6 +15,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Tudoong"
         tools:targetApi="31">
+
+        <receiver
+            android:name=".widget.TudoongWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/tudoong_widget_info" />
+        </receiver>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/chch/tudoong/TudoongApplication.kt
+++ b/app/src/main/java/com/chch/tudoong/TudoongApplication.kt
@@ -1,7 +1,33 @@
 package com.chch.tudoong
 
 import android.app.Application
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.chch.tudoong.utils.logd
+import com.chch.tudoong.widget.WidgetUpdateManager
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.launch
 
 @HiltAndroidApp
-class TudoongApplication : Application()
+class TudoongApplication : Application(){
+
+    override fun onCreate() {
+        super.onCreate()
+        ProcessLifecycleOwner.get().lifecycle.addObserver(AppLifecycleObserver(this))
+    }
+
+    private class AppLifecycleObserver(
+        private val context: Context
+    ) : DefaultLifecycleObserver {
+
+        override fun onStop(owner: LifecycleOwner) {
+            owner.lifecycleScope.launch{
+                WidgetUpdateManager.updateIfNeeded(context)
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/data/repository/TudoongRepository.kt
@@ -1,5 +1,6 @@
 package com.chch.tudoong.data.repository
 
+import android.content.Context
 import com.chch.tudoong.data.local.database.dao.DailyDao
 import com.chch.tudoong.data.local.database.dao.MetadataDao
 import com.chch.tudoong.data.local.database.dao.TodoDao
@@ -8,6 +9,8 @@ import com.chch.tudoong.data.local.database.entities.DailyItem
 import com.chch.tudoong.data.local.database.entities.TodoItem
 import com.chch.tudoong.domain.model.TodoType
 import com.chch.tudoong.utils.DateUtils
+import com.chch.tudoong.widget.WidgetUpdateManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -20,6 +23,7 @@ class TudoongRepository @Inject constructor(
     private val todoDao: TodoDao,
     private val dailyDao: DailyDao,
     private val metadataDao: MetadataDao,
+    @ApplicationContext private val context: Context,
 ) {
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
@@ -38,14 +42,17 @@ class TudoongRepository @Inject constructor(
     suspend fun addTodoItem(text: String) {
         val todoItem = TodoItem(text = text, type = TodoType.TODAY)
         todoDao.insertTodo(todoItem)
+        WidgetUpdateManager.markForUpdate()
     }
 
     suspend fun updateTodoItem(todoItem: TodoItem) {
         todoDao.updateTodo(todoItem)
+        WidgetUpdateManager.markForUpdate()
     }
 
     suspend fun deleteTodoItem(todoItem: TodoItem) {
         todoDao.deleteTodo(todoItem)
+        WidgetUpdateManager.markForUpdate()
     }
 
     suspend fun addDailyItem(text: String) {
@@ -126,5 +133,7 @@ class TudoongRepository @Inject constructor(
         // 메타데이터 업데이트
         metadataDao.updateLastResetDate(today)
         metadataDao.updateTodayDate(today)
+
+        WidgetUpdateManager.markForUpdate()
     }
 }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
@@ -1,13 +1,25 @@
 package com.chch.tudoong.widget
 
 import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
+import androidx.glance.currentState
+import androidx.glance.state.GlanceStateDefinition
+import androidx.glance.state.PreferencesGlanceStateDefinition
 import com.chch.tudoong.utils.DateUtils
 import dagger.hilt.android.EntryPointAccessors
 
+// Preference keys
+object PrefsKeys {
+    val TODO_ITEMS_KEY = stringPreferencesKey("todoItems")
+}
+
 class TudoongAppWidget : GlanceAppWidget() {
+
+    override var stateDefinition: GlanceStateDefinition<*> = PreferencesGlanceStateDefinition
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
 
@@ -16,22 +28,16 @@ class TudoongAppWidget : GlanceAppWidget() {
             WidgetEntryPoint::class.java
         ).widgetRepository()
 
-        val todos = try {
-            repository.getTodoItems()
-        } catch (e: Exception) {
-            emptyList<TodoWidgetItem>()
-        }
+        // Load data
+        val todos = runCatching { repository.getTodoItems() }.getOrDefault(emptyList())
+        val metadata = runCatching { repository.getMetadata() }.getOrNull()
+        val todayDate = metadata?.let { DateUtils.formatDateWithDayOfWeek(it.todayDate) } ?: ""
 
-        val metadata = try {
-            repository.getMetadata()
-        } catch (e: Exception) {
-            null
-        }
-
-        val todayDate = if (metadata != null) DateUtils.formatDateWithDayOfWeek(metadata.todayDate)
-                        else ""
         provideContent {
-            TudoongWidgetContent(todos, todayDate)
+            val prefs = currentState<Preferences>()
+            val todosString = prefs[PrefsKeys.TODO_ITEMS_KEY]
+            val todolist = todosString?.let { deserializeTodos(it) } ?: todos
+            TudoongWidgetContent(todolist, todayDate)
 
         }
     }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
@@ -1,0 +1,29 @@
+package com.chch.tudoong.widget
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.provideContent
+import androidx.glance.text.Text
+import dagger.hilt.android.EntryPointAccessors
+
+class TudoongAppWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+
+        // In this method, load data needed to render the AppWidget.
+        // Use `withContext` to switch to another thread for long running
+        // operations.
+        val repository = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            WidgetEntryPoint::class.java
+        ).widgetRepository()
+
+        provideContent {
+            // create your AppWidget here
+            Text("Tudoong 위젯입니다")
+//            TudoongWidgetContent(repository)
+
+        }
+    }
+}

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongAppWidget.kt
@@ -4,25 +4,34 @@ import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
-import androidx.glance.text.Text
+import com.chch.tudoong.utils.DateUtils
 import dagger.hilt.android.EntryPointAccessors
 
 class TudoongAppWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
 
-        // In this method, load data needed to render the AppWidget.
-        // Use `withContext` to switch to another thread for long running
-        // operations.
         val repository = EntryPointAccessors.fromApplication(
             context.applicationContext,
             WidgetEntryPoint::class.java
         ).widgetRepository()
 
+        val todos = try {
+            repository.getTodoItems()
+        } catch (e: Exception) {
+            emptyList<TodoWidgetItem>()
+        }
+
+        val metadata = try {
+            repository.getMetadata()
+        } catch (e: Exception) {
+            null
+        }
+
+        val todayDate = if (metadata != null) DateUtils.formatDateWithDayOfWeek(metadata.todayDate)
+                        else ""
         provideContent {
-            // create your AppWidget here
-            Text("Tudoong 위젯입니다")
-//            TudoongWidgetContent(repository)
+            TudoongWidgetContent(todos, todayDate)
 
         }
     }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
@@ -8,9 +8,9 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
 import androidx.glance.appwidget.enabled
-import androidx.glance.appwidget.lazy.LazyColumn
-import androidx.glance.appwidget.lazy.items
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -26,6 +26,7 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import com.chch.tudoong.MainActivity
 import com.chch.tudoong.R
 
 @SuppressLint("RestrictedApi")
@@ -34,9 +35,12 @@ fun TudoongWidgetContent(
     todos: List<TodoWidgetItem>,
     todayDate: String,
 ) {
+    val openAppAction = actionStartActivity<MainActivity>()
 
     Column(
-        modifier = GlanceModifier.fillMaxSize(),
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .clickable(openAppAction),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -49,15 +53,16 @@ fun TudoongWidgetContent(
                 .fillMaxWidth()
                 .background(Color.LightGray)
                 .padding(start = 15.dp, top = 5.dp, bottom = 5.dp)
+
         )
-        LazyColumn(
+        Column(
             modifier = GlanceModifier
                 .fillMaxSize()
                 .background(Color.White)
                 .padding(10.dp)
         ) {
 
-            items(todos) { item ->
+            todos.forEach { item ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -95,19 +100,18 @@ fun TudoongWidgetContent(
             }
 
             if (todos.isEmpty()) {
-                item {
-                    Text(
-                        text = "There are no tasks for today.",
-                        style = TextStyle(
-                            fontSize = 14.sp,
-                            color = ColorProvider(R.color.gray)
-                        ),
-                        modifier = GlanceModifier.padding(top = 16.dp)
-                    )
-                }
+                Text(
+                    text = "There are no tasks for today.",
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        color = ColorProvider(R.color.gray)
+                    ),
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .padding(top = 10.dp)
+                )
+
             }
         }
     }
-
-
 }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
@@ -1,10 +1,7 @@
 package com.chch.tudoong.widget
 
-import androidx.compose.material3.CircularProgressIndicator
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -12,44 +9,19 @@ import androidx.glance.GlanceModifier
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.lazy.items
 import androidx.glance.background
-import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.chch.tudoong.R
 
+@SuppressLint("RestrictedApi")
 @Composable
-fun TudoongWidgetContent(repository: WidgetRepository){
-    val todos = remember { mutableStateOf<List<TodoWidgetItem>>(emptyList()) }
-    val isLoading = remember { mutableStateOf(true) }
-
-    LaunchedEffect(Unit) {
-        try {
-            todos.value = repository.getTodoItems()
-        } catch (e: Exception) {
-            // 에러 처리
-        } finally {
-            isLoading.value = false
-        }
-    }
-
-    if (isLoading.value) {
-        Box(
-            modifier = GlanceModifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            CircularProgressIndicator()
-        }
-    } else {
-        TudoongWidgetList(todos.value)
-    }
-}
-
-@Composable
-fun TudoongWidgetList(
-    todos : List<TodoWidgetItem>
+fun TudoongWidgetContent(
+    todos : List<TodoWidgetItem>,
+    todayDate: String
 ){
     LazyColumn(
         modifier = GlanceModifier
@@ -59,7 +31,7 @@ fun TudoongWidgetList(
     ) {
         item {
             Text(
-                text = "할 일 목록",
+                text = todayDate,
                 style = TextStyle(
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold
@@ -72,6 +44,19 @@ fun TudoongWidgetList(
             Text(
                 text = item.text
             )
+        }
+
+        if(todos.isEmpty()){
+            item {
+                Text(
+                    text = "There are no tasks for today.",
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        color = ColorProvider(R.color.gray)
+                    ),
+                    modifier = GlanceModifier.padding(top = 16.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
@@ -6,11 +6,22 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.appwidget.enabled
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.lazy.items
 import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -20,43 +31,83 @@ import com.chch.tudoong.R
 @SuppressLint("RestrictedApi")
 @Composable
 fun TudoongWidgetContent(
-    todos : List<TodoWidgetItem>,
-    todayDate: String
-){
-    LazyColumn(
-        modifier = GlanceModifier
-            .fillMaxSize()
-            .background(Color.White)
-            .padding(16.dp)
+    todos: List<TodoWidgetItem>,
+    todayDate: String,
+) {
+
+    Column(
+        modifier = GlanceModifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        item {
-            Text(
-                text = todayDate,
-                style = TextStyle(
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold
-                ),
-                modifier = GlanceModifier.padding(bottom = 8.dp)
-            )
-        }
+        Text(
+            text = todayDate,
+            style = TextStyle(
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .background(Color.LightGray)
+                .padding(start = 15.dp, top = 5.dp, bottom = 5.dp)
+        )
+        LazyColumn(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(10.dp)
+        ) {
 
-        items(todos) {item ->
-            Text(
-                text = item.text
-            )
-        }
+            items(todos) { item ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val bgRes = if (item.isMissed) R.drawable.widget_checkbox_border_missed
+                    else if (item.isCompleted) R.drawable.widget_checkbox_border_complete
+                    else R.drawable.widget_checkbox_border
+                    Box(
+                        modifier = GlanceModifier
+                            .enabled(item.isMissed)
+                            .background(ImageProvider(bgRes))
+                            .size(18.dp)
+                    ) {
+                        val imageRes = if (item.isMissed) R.drawable.ic_remove_24
+                        else if (item.isCompleted) R.drawable.ic_check_24
+                        else null
+                        imageRes?.let {
+                            Image(
+                                provider = ImageProvider(imageRes),
+                                contentDescription = "checkbox icon"
+                            )
+                        }
+                    }
 
-        if(todos.isEmpty()){
-            item {
-                Text(
-                    text = "There are no tasks for today.",
-                    style = TextStyle(
-                        fontSize = 14.sp,
-                        color = ColorProvider(R.color.gray)
-                    ),
-                    modifier = GlanceModifier.padding(top = 16.dp)
-                )
+                    Spacer(GlanceModifier.width(3.dp))
+
+
+                    Text(
+                        text = item.text,
+                        maxLines = 1,
+                        style = TextStyle(
+                            color = ColorProvider(if (item.isMissed) R.color.on_surface_variant_alpha60 else R.color.primary)
+                        )
+                    )
+                }
+            }
+
+            if (todos.isEmpty()) {
+                item {
+                    Text(
+                        text = "There are no tasks for today.",
+                        style = TextStyle(
+                            fontSize = 14.sp,
+                            color = ColorProvider(R.color.gray)
+                        ),
+                        modifier = GlanceModifier.padding(top = 16.dp)
+                    )
+                }
             }
         }
     }
+
+
 }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetContent.kt
@@ -1,0 +1,77 @@
+package com.chch.tudoong.widget
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+
+@Composable
+fun TudoongWidgetContent(repository: WidgetRepository){
+    val todos = remember { mutableStateOf<List<TodoWidgetItem>>(emptyList()) }
+    val isLoading = remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        try {
+            todos.value = repository.getTodoItems()
+        } catch (e: Exception) {
+            // 에러 처리
+        } finally {
+            isLoading.value = false
+        }
+    }
+
+    if (isLoading.value) {
+        Box(
+            modifier = GlanceModifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else {
+        TudoongWidgetList(todos.value)
+    }
+}
+
+@Composable
+fun TudoongWidgetList(
+    todos : List<TodoWidgetItem>
+){
+    LazyColumn(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        item {
+            Text(
+                text = "할 일 목록",
+                style = TextStyle(
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                modifier = GlanceModifier.padding(bottom = 8.dp)
+            )
+        }
+
+        items(todos) {item ->
+            Text(
+                text = item.text
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetReceiver.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package com.chch.tudoong.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class TudoongWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = TudoongAppWidget()
+
+}

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetReceiver.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetReceiver.kt
@@ -5,5 +5,4 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
 class TudoongWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = TudoongAppWidget()
-
 }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
@@ -1,6 +1,8 @@
 package com.chch.tudoong.widget
 
+import androidx.room.PrimaryKey
 import com.chch.tudoong.data.repository.TudoongRepository
+import com.chch.tudoong.utils.logd
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -12,6 +14,12 @@ data class TodoWidgetItem(
     val isCompleted: Boolean = false,
     val isMissed: Boolean = false
 )
+data class WidgetMetadata(
+    val resetHour : Int = 7,
+    val resetMin : Int = 0,
+    val lastResetData : String = "",
+    val todayDate : String = ""
+)
 
 // 위젯용 레포지터리
 @Singleton
@@ -19,12 +27,24 @@ class WidgetRepository @Inject constructor(
     private val tudoongRepository: TudoongRepository
 ) {
     suspend fun getTodoItems(): List<TodoWidgetItem> {
-        return tudoongRepository.getTodayTodos().map { todo ->
+        val list = tudoongRepository.getTodayTodos().map { todo ->
             TodoWidgetItem(
                 id = todo.id,
                 text = todo.text,
                 isCompleted = todo.isCompleted,
                 isMissed = todo.isMissed
+            )
+        }
+        return list
+    }
+
+    suspend fun getMetadata() : WidgetMetadata {
+        return tudoongRepository.getMetadata().let {
+            WidgetMetadata(
+                resetHour = it.resetHour,
+                resetMin = it.resetMin,
+                lastResetData = it.lastResetDate,
+                todayDate = it.todayDate
             )
         }
     }

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
@@ -1,0 +1,31 @@
+package com.chch.tudoong.widget
+
+import com.chch.tudoong.data.repository.TudoongRepository
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// 위젯 데이터 클래스
+data class TodoWidgetItem(
+    val id: String = UUID.randomUUID().toString(),
+    val text: String,
+    val isCompleted: Boolean = false,
+    val isMissed: Boolean = false
+)
+
+// 위젯용 레포지터리
+@Singleton
+class WidgetRepository @Inject constructor(
+    private val tudoongRepository: TudoongRepository
+) {
+    suspend fun getTodoItems(): List<TodoWidgetItem> {
+        return tudoongRepository.getTodayTodos().map { todo ->
+            TodoWidgetItem(
+                id = todo.id,
+                text = todo.text,
+                isCompleted = todo.isCompleted,
+                isMissed = todo.isMissed
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/TudoongWidgetRepository.kt
@@ -1,25 +1,8 @@
 package com.chch.tudoong.widget
 
-import androidx.room.PrimaryKey
 import com.chch.tudoong.data.repository.TudoongRepository
-import com.chch.tudoong.utils.logd
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
-
-// 위젯 데이터 클래스
-data class TodoWidgetItem(
-    val id: String = UUID.randomUUID().toString(),
-    val text: String,
-    val isCompleted: Boolean = false,
-    val isMissed: Boolean = false
-)
-data class WidgetMetadata(
-    val resetHour : Int = 7,
-    val resetMin : Int = 0,
-    val lastResetData : String = "",
-    val todayDate : String = ""
-)
 
 // 위젯용 레포지터리
 @Singleton

--- a/app/src/main/java/com/chch/tudoong/widget/WidgetData.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/WidgetData.kt
@@ -1,0 +1,39 @@
+package com.chch.tudoong.widget
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+// 위젯 데이터 클래스
+@Serializable
+data class TodoWidgetItem(
+    val id: String = UUID.randomUUID().toString(),
+    val text: String,
+    val isCompleted: Boolean = false,
+    val isMissed: Boolean = false,
+)
+
+// 위젯 메타데이터
+data class WidgetMetadata(
+    val id: Int = 1,
+    val resetHour: Int = 7,
+    val resetMin: Int = 0,
+    val lastResetData: String = "",
+    val todayDate: String = "",
+)
+
+
+// 직렬화: List<TodoWidgetItem> → String
+fun serializeTodos(list: List<TodoWidgetItem>): String =
+    Json.encodeToString(
+        ListSerializer(TodoWidgetItem.serializer()),
+        list
+    )
+
+// 역직렬화: String → List<TodoWidgetItem>
+fun deserializeTodos(json: String): List<TodoWidgetItem> =
+    Json.decodeFromString(
+        ListSerializer(TodoWidgetItem.serializer()),
+        json
+    )

--- a/app/src/main/java/com/chch/tudoong/widget/WidgetEntryPoint.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/WidgetEntryPoint.kt
@@ -1,0 +1,11 @@
+package com.chch.tudoong.widget
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WidgetEntryPoint {
+    fun widgetRepository(): WidgetRepository
+}

--- a/app/src/main/java/com/chch/tudoong/widget/WidgetUpdateManager.kt
+++ b/app/src/main/java/com/chch/tudoong/widget/WidgetUpdateManager.kt
@@ -1,0 +1,42 @@
+package com.chch.tudoong.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicBoolean
+
+object WidgetUpdateManager {
+
+    private val needsUpdate = AtomicBoolean(false)
+
+    fun markForUpdate() {
+        needsUpdate.set(true)
+    }
+
+    suspend fun updateIfNeeded(context: Context) {
+        if (needsUpdate.compareAndSet(true, false)) {
+            context.updateAllWidgets()
+        }
+    }
+}
+
+suspend fun Context.updateAllWidgets() {
+
+    val repository = EntryPointAccessors.fromApplication(
+        this.applicationContext,
+        WidgetEntryPoint::class.java
+    ).widgetRepository()
+    val todos = runCatching { repository.getTodoItems() }.getOrDefault(emptyList())
+    GlanceAppWidgetManager(this)
+        .getGlanceIds(TudoongAppWidget::class.java)
+        .forEach { glanceId ->
+            updateAppWidgetState(this, glanceId) { prefs ->
+                prefs[PrefsKeys.TODO_ITEMS_KEY] = serializeTodos(todos)
+            }.let {
+                delay(500)
+                TudoongAppWidget().update(this, glanceId)
+            }
+        }
+}

--- a/app/src/main/res/drawable/ic_check_24.xml
+++ b/app/src/main/res/drawable/ic_check_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/on_primary" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M382,720L154,492L211,435L382,606L749,239L806,296L382,720Z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_remove_24.xml
+++ b/app/src/main/res/drawable/ic_remove_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/on_surface_variant" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M200,520L200,440L760,440L760,520L200,520Z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/widget_checkbox_border.xml
+++ b/app/src/main/res/drawable/widget_checkbox_border.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="1dp" android:color="@color/outline" />
+    <corners android:radius="3dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_checkbox_border_complete.xml
+++ b/app/src/main/res/drawable/widget_checkbox_border_complete.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary" />
+    <stroke android:width="1dp" android:color="@color/primary" />
+    <corners android:radius="3dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_checkbox_border_missed.xml
+++ b/app/src/main/res/drawable/widget_checkbox_border_missed.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/surface_variant" />
+    <stroke android:width="1dp" android:color="@color/outline" />
+    <corners android:radius="3dp" />
+</shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gray">#FF888888</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,11 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="gray">#FF888888</color>
+
+    <color name="outline">#FF75796C</color>
+    <color name="primary">#FF253D05</color>
+    <color name="on_primary">#FFFFFFFF</color>
+    <color name="surface_variant">#FFE1E4D5</color>
+    <color name="on_surface_variant">#FF34382D</color>
+    <color name="on_surface_variant_alpha60">#9934382D</color>
 </resources>

--- a/app/src/main/res/xml-v31/tudoong_widget_info.xml
+++ b/app/src/main/res/xml-v31/tudoong_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2" />

--- a/app/src/main/res/xml-v31/tudoong_widget_info.xml
+++ b/app/src/main/res/xml-v31/tudoong_widget_info.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="180dp"
+    android:minWidth="60dp"
+    android:minHeight="60dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/glance_default_loading_layout"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
-    android:targetCellWidth="3"
+    android:targetCellWidth="2"
     android:targetCellHeight="2" />

--- a/app/src/main/res/xml/tudoong_widget_info.xml
+++ b/app/src/main/res/xml/tudoong_widget_info.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="180dp"
+    android:minWidth="60dp"
+    android:minHeight="60dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/glance_default_loading_layout"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
-    android:targetCellWidth="3"
-    android:targetCellHeight="2" />
+ />

--- a/app/src/main/res/xml/tudoong_widget_info.xml
+++ b/app/src/main/res/xml/tudoong_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.kotlinx.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+kotlinxSerializationJson = "1.7.3"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.01"
@@ -20,6 +21,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glanceMaterial3" }
 androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glanceMaterial3" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
@@ -42,6 +44,7 @@ androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -49,6 +52,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version = "2.0.21-1.0.27" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltCompiler"}
-
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "1.6.21" }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.10.1"
+glanceMaterial3 = "1.1.1"
 hiltCompiler = "2.56.2"
 hiltNavigationCompose = "1.2.0"
 kotlin = "2.0.21"
@@ -16,6 +17,8 @@ navigationCompose = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glanceMaterial3" }
+androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glanceMaterial3" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }


### PR DESCRIPTION
Implement and enhance the Tudoong home-screen widget using Jetpack Glance, enabling real-time updates only when the todo list changes.

Add Glance‐based home widget for Tudoong
- Define TudoongAppWidget & Receiver
- Show tri-state checkboxes and enable tap to open app
- Refresh only on data change via WidgetUpdateManager & onStop() + Context.updateAllWidgets()


Checklist
- Widget appears correctly on add
- Updates when todos change and opens app on tap